### PR TITLE
tweak: close command palette on cmd+w before tab is closed

### DIFF
--- a/Pulse/PulseApp.swift
+++ b/Pulse/PulseApp.swift
@@ -162,7 +162,11 @@ struct PulseCommands: Commands {
             .keyboardShortcut("n", modifiers: .command)
 
             Button("Close Tab") {
-                browserManager.closeCurrentTab()
+                if browserManager.isCommandPaletteVisible {
+                    browserManager.closeCommandPalette()
+                } else {
+                    browserManager.closeCurrentTab()
+                }
             }
             .keyboardShortcut("w", modifiers: .command)
             .disabled(browserManager.tabManager.tabs.isEmpty)


### PR DESCRIPTION
When a user presses command + w (close tab), close the command palette, and then the user has to press it again to close the tab