### PR TITLE
Refactor skip button logic in StageFooter

### DIFF
--- a/Onboarding/Components/StageFooter.swift
+++ b/Onboarding/Components/StageFooter.swift
@@ -65,7 +65,14 @@ struct StageFooter: View {
             .disabled(isLoading)
             if !(currentStage == 0) {
                 Button {
-                    if currentStage > 0 { onBack() }
+                    if currentStage > 0 {
+                        if currentStage == 1 {
+                            // Skip at stage 1 should advance, not go back
+                            onContinue()
+                        } else {
+                            onBack()
+                        }
+                    }
                 } label: {
                     Text(secondaryText)
                         .font(.system(size: 14, weight: .semibold))

--- a/Onboarding/Components/StageFooter.swift
+++ b/Onboarding/Components/StageFooter.swift
@@ -65,13 +65,10 @@ struct StageFooter: View {
             .disabled(isLoading)
             if !(currentStage == 0) {
                 Button {
-                    if currentStage > 0 {
-                        if currentStage == 1 {
-                            // Skip at stage 1 should advance, not go back
-                            onContinue()
-                        } else {
-                            onBack()
-                        }
+                    if currentStage == 1 {
+                        onContinue()
+                    } else {
+                        onBack()
                     }
                 } label: {
                     Text(secondaryText)

--- a/Onboarding/Components/StageFooter.swift
+++ b/Onboarding/Components/StageFooter.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct StageFooter: View {
     var currentStage: Int
     var isLoading: Bool = false


### PR DESCRIPTION
This should make the skip button work. Previously the skip button would go back and not forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding footer button behavior corrected: the secondary button now performs the appropriate skip or back action based on the current onboarding step, fixing incorrect navigation for certain stages and ensuring consistent forward/backward flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->